### PR TITLE
Adding initial README tag script framework to repo

### DIFF
--- a/.github/scripts/readme_tag_update.py
+++ b/.github/scripts/readme_tag_update.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+
+"""
+Script name:  readme_tag_update.py
+
+Goal:  To determine if a recent push to the "development" branch
+       was for a tag, and if so, to update the README.md file on
+       the master branch to display the new development tag.
+
+
+Written by:  Jesse Nusbaumer <nusbaume@ucar.edu> - February, 2020
+"""
+
+#+++++++++++++++++++++
+#Import needed modules
+#+++++++++++++++++++++
+
+import re
+import sys
+import subprocess
+import shlex
+import argparse
+
+from github import Github
+
+#################
+#HELPER FUNCTIONS
+#################
+
+#++++++++++++++++++++++++++++++
+#Input Argument parser function
+#++++++++++++++++++++++++++++++
+
+def parse_arguments():
+
+    """
+    Parses command-line input arguments using the argparse
+    python module and outputs the final argument object.
+    """
+
+    #Create parser object:
+    parser = argparse.ArgumentParser(description='Close issues and pull requests specified in merged pull request.')
+
+    #Add input arguments to be parsed:
+    parser.add_argument('--access_token', metavar='<GITHUB_TOKEN>', action='store', type=str,
+                        help="access token used to access GitHub API")
+
+    parser.add_argument('--trigger_sha', metavar='<GITHUB SHA>', action='store', type=str,
+                        help="Commit SHA that triggered the workflow")
+
+    #Parse Argument inputs
+    args = parser.parse_args()
+    return args
+
+#++++++++++++++++++++++++++++++++
+#Script message and exit function
+#++++++++++++++++++++++++++++++++
+
+def end_script(msg):
+
+    """
+    Prints message to screen, and then exits script.
+    """
+    print("\n{}\n".format(msg))
+    print("README tag update script has completed successfully.")
+    sys.exit(0)
+
+#############
+#MAIN PROGRAM
+#############
+
+def _main_prog():
+
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
+
+    #++++++++++++
+    #Begin script
+    #++++++++++++
+
+    print("Checking if README file needs to be updated...")
+
+    #+++++++++++++++++++++++
+    #Read in input arguments
+    #+++++++++++++++++++++++
+
+    args = parse_arguments()
+
+    #Add argument values to variables:
+    token = args.access_token
+    trigger_sha = args.trigger_sha
+
+    #++++++++++++++++++++++++++++++++
+    #Log-in to github API using token
+    #++++++++++++++++++++++++++++++++
+
+    ghub = Github(token)
+
+    #++++++++++++++++++++
+    #Open ESCOMP/CAM repo
+    #++++++++++++++++++++
+
+    #Official CAM repo:
+    cam_repo = ghub.get_repo("NCAR/repoForTestingCAM")
+
+    #+++++++++++++++++++++
+    #Get list of repo tags
+    #+++++++++++++++++++++
+
+    cam_tags = cam_repo.get_tags()
+
+    #+++++++++++++++++++++++++++++++++++++++++++
+    #Search for tag with sha that matches commit
+    #+++++++++++++++++++++++++++++++++++++++++++
+
+    tag_name = None
+
+    for cam_tag in cam_tags:
+        if cam_tag.commit.sha == trigger_sha:
+            tag_name = cam_tag.name
+
+    #+++++++++++++++++++++++++++++++++++
+    #If no tag matches, then exit script
+    #+++++++++++++++++++++++++++++++++++
+
+    if tag_name:
+        endmsg = "No tag was created by this push, so there is nothing to do."
+        end_script(endmsg)
+
+    #++++++++++++++++++++++++++++++++++
+    #Upate README file on master branch
+    #++++++++++++++++++++++++++++++++++
+
+    #CONTINUE HERE!!!!!!!!!!!!!!
+
+    #++++++++++
+    #End script
+    #++++++++++
+
+    print("cam_development tag has been successfully updated in README file.")
+
+#############################################
+
+#Run the main script program:
+if __name__ == "__main__":
+    _main_prog()

--- a/.github/scripts/readme_tag_update.py
+++ b/.github/scripts/readme_tag_update.py
@@ -124,7 +124,7 @@ def _main_prog():
     #If no tag matches, then exit script
     #+++++++++++++++++++++++++++++++++++
 
-    if tag_name:
+    if not tag_name:
         endmsg = "No tag was created by this push, so there is nothing to do."
         end_script(endmsg)
 
@@ -132,6 +132,7 @@ def _main_prog():
     #Upate README file on master branch
     #++++++++++++++++++++++++++++++++++
 
+    print("Script found tag name of '{}'".format(tag_name))
     #CONTINUE HERE!!!!!!!!!!!!!!
 
     #++++++++++

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -32,10 +32,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip  # Install latest version of PIP
         pip install PyGithub                 # Install PyGithub pythong package
-    # run CAM issue-closing script
-    - name: python action scripts
+    # run CAM issue-closing and README tag update scripts
+    - name: python issue and README tag scripts
       if: github.repository == 'NCAR/repoForTestingCAM' #Only run on main repo
       env:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         TRIGGER_SHA: ${{ github.sha }}
-      run: .github/scripts/branch_pr_issue_closer.py --access_token $ACCESS_TOKEN --trigger_sha $TRIGGER_SHA
+      run: |
+        #Issue-closing script:
+        .github/scripts/branch_pr_issue_closer.py --access_token $ACCESS_TOKEN --trigger_sha $TRIGGER_SHA
+        #README tag-updating script:
+        .github/scripts/readme_tag_update.py --access_token $ACCESS_TOKEN --trigger_sha $TRIGGER_SHA
+        #Debugging output:
+        echo $TRIGGER_SHA
+        echo $GITHUB_SHA
+        echo $GITHUB_REF
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # repoForTestingCAM
 This repo is solely for testing purposes
+
+The information below is solely for testing CI/CD scripts, and has nothing to do with the actual code in this repo.
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+### To use unsupported CAM **development** code:
+
+## NOTE: This is **unsupported** development code and is subject to the [CESM developer's agreement](http://www.cgd.ucar.edu/cseg/development-code.html).
+<!-- First line of CAM-dev tag code -->
+```
+git checkout cam6_3_002
+./manage_externals/checkout_externals
+```
+<!-- Last line of CAM-dev tag code -->
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
This is required in order to test certain Github Action workflow environment variables, which may be needed by the README updating script itself.