### PR TITLE
Fix bad character case in tag readme update script.

### DIFF
--- a/.github/scripts/tag_check_readme_update.py
+++ b/.github/scripts/tag_check_readme_update.py
@@ -260,7 +260,7 @@ def _main_prog():
         end_script_fail(endmsg)
     else:
         #Find first occurence of "Originator", to set tag search end:
-        orig_log_idx = changelog.find("Originator")
+        orig_log_idx = changelog.find("originator")
         if orig_log_idx == -1:
             endmsg = "No 'Originator' entry found in the ChangeLog!\n"
             endmsg += "The ChangeLog file has likely been corrupted."


### PR DESCRIPTION
Fix another typo (this time an improper capitalization) in the tag readme update script.